### PR TITLE
Fix OSM API URL format

### DIFF
--- a/sugartrail/processing.py
+++ b/sugartrail/processing.py
@@ -70,8 +70,8 @@ def get_nearby_postcode(postcode_string):
 
 def get_coords_from_address(address_string):
     """Attempt retrieval of coords for input address string."""
-    address = urllib.parse.quote(address_string)
-    url = 'https://nominatim.openstreetmap.org/search/' + urllib.parse.quote(address) +'?format=json'
+    params = {'q': address_string, 'format': 'json'}
+    url = 'https://nominatim.openstreetmap.org/search?' + urllib.parse.urlencode(params)
     response = requests.get(url).json()
     if response:
         return {'lat': response[0]['lat'], 'lon': response[0]['lon'], 'address': address_string}


### PR DESCRIPTION
The OSM search API no longer supports the URL format currently in use

See: https://github.com/osm-search/Nominatim/issues/3134

e.g. https://nominatim.openstreetmap.org/search/London%2520N15%25206BL?format=json now gives an error

<img width="833" alt="Screenshot 2023-09-08 at 13 24 23" src="https://github.com/ribenamaplesyrup/sugartrail/assets/11772383/78eaae14-6aca-4a75-a68e-3a4d3543868e">
